### PR TITLE
Tpose / Bindpose loading from FBX

### DIFF
--- a/DX11-Refresh/Fbx_Loader.cpp
+++ b/DX11-Refresh/Fbx_Loader.cpp
@@ -257,6 +257,7 @@ namespace {
 						curr_index_weight_pair.index = curr_joint_index;
 						curr_index_weight_pair.weight = curr_cluster->GetControlPointWeights()[i];
 						temp[curr_cluster->GetControlPointIndices()[i]].push_back(curr_index_weight_pair);
+						curr_joint->mConnectedVertexIndices.push_back(curr_joint_index);
 					}
 
 					FbxAnimStack* curr_anim_stack = FbxCast<FbxAnimStack>(inNode->GetScene()->GetSrcObject<FbxAnimStack>());

--- a/DX11-Refresh/Fbx_loader.h
+++ b/DX11-Refresh/Fbx_loader.h
@@ -54,6 +54,8 @@ struct Joint {
 	std::vector<KeyFrame> mAnimationVector;
 	FbxNode* mNode;
 
+	std::vector<unsigned int> mConnectedVertexIndices;
+
 	FbxAMatrix mGlobalBindposeInverse;
 	FbxAMatrix mBoneGlobalTransform;
 	FbxAMatrix mOffsetMatrix;


### PR DESCRIPTION
The engine now asks for the .fbx file to contain a 1 frame animation named TPOSE when loading an animated file, and uses this for all subsequent animations.