### PR TITLE
Load Multiple Animations

### DIFF
--- a/DX11-Refresh/Fbx_Loader.cpp
+++ b/DX11-Refresh/Fbx_Loader.cpp
@@ -489,9 +489,10 @@ HRESULT FbxLoader::LoadFBX(const std::string& fileName, std::vector<DirectX::XMF
 				::LoadUV(p_mesh, pOutUVVector);
 				// Transform the mesh using the appropriate root transformation matrix
 
-				FbxAMatrix conversion_transform = FbxAMatrix(FbxVector4(0.0f, 0.0f, 0.0f), FbxVector4(-90.0f, 0.0f, 0.0f), FbxVector4(1.0f, -1.0f, 1.0f));
+				
 				for (int j = 0; j < p_mesh->GetControlPointsCount(); ++j)
 				{
+					FbxAMatrix conversion_transform = FbxAMatrix(FbxVector4(0.0f, 0.0f, 0.0f), FbxVector4(-90.0f, 0.0f, 0.0f), FbxVector4(1.0f, -1.0f, 1.0f));
 					DirectX::XMFLOAT3 vertex_pos;
 					FbxVector4 fbx_vertex = p_vertices[j];
 					fbx_vertex = conversion_transform.MultT(p_vertices[j]);
@@ -528,7 +529,7 @@ HRESULT FbxLoader::LoadFBX(const std::string& fileName, std::vector<DirectX::XMF
 						throw std::exception("Invalid Fbx Normal Reference");
 					}
 					DirectX::XMFLOAT3 vertex_normal;
-
+					conversion_transform = FbxAMatrix(FbxVector4(0.0f, 0.0f, 0.0f), FbxVector4(-90.0f, 0.0f, 0.0f), FbxVector4(-1.0f, 1.0f, -1.0f));
 					// Transform the normals in the same manner as the vertices
 					normal = conversion_transform.MultT(normal);
 					normal.Normalize();

--- a/DX11-Refresh/Fbx_Loader.cpp
+++ b/DX11-Refresh/Fbx_Loader.cpp
@@ -288,7 +288,7 @@ namespace {
 					if (ending == std::string("TPOSE"))
 					{
 						has_tpose = true;
-						for (int cluster_index = 0; cluster_index < num_of_clusters; ++cluster_index)
+						for (unsigned int cluster_index = 0; cluster_index < num_of_clusters; ++cluster_index)
 						{
 							// Collect info about the current joint
 							FbxCluster* curr_cluster = curr_skin->GetCluster(cluster_index);
@@ -347,18 +347,13 @@ namespace {
 
 					// Create the AnimationSet for this animation
 					FbxLoader::AnimationSet tempAnimSet;
-					tempAnimSet.frameCount = animation_length;
+					tempAnimSet.frameCount = (unsigned int)animation_length;
 					tempAnimSet.animationName = animation_name;
 
 					std::vector<DirectX::XMFLOAT4X4> tempJointOffsetMatrixVector;
 
-					FbxAnimEvaluator* anim_eval = inNode->GetScene()->GetAnimationEvaluator();
-					FbxNodeEvalState* evalstate;
-					
-					
-
 					// bindposes have already been calculated at this point, we just need the offset matrices for each joint
-					for (int cluster_index = 0; cluster_index < num_of_clusters; ++cluster_index)
+					for (unsigned int cluster_index = 0; cluster_index < num_of_clusters; ++cluster_index)
 					{
 						// Collect info about the current joint
 						FbxCluster* curr_cluster = curr_skin->GetCluster(cluster_index);
@@ -411,9 +406,9 @@ namespace {
 
 					// Fill the Animation Set with the collected data
 					tempAnimSet.animationData = new DirectX::XMFLOAT4X4[animation_length * num_of_clusters];
-					for (int frame_index = 0; frame_index < animation_length; ++frame_index)
+					for (unsigned int frame_index = 0; frame_index < (unsigned int)animation_length; ++frame_index)
 					{
-						for (int joint_index = 0; joint_index < num_of_clusters; ++joint_index)
+						for (unsigned int joint_index = 0; joint_index < num_of_clusters; ++joint_index)
 						{
 							tempAnimSet.animationData[frame_index * num_of_clusters + joint_index] = tempJointOffsetMatrixVector[joint_index * animation_length + frame_index];
 						}
@@ -427,7 +422,7 @@ namespace {
 					skeleton->animationFlags[i] = 0;
 				}
 			}
-			skeleton->jointCount = skeleton->joints.size();
+			skeleton->jointCount = (unsigned int)skeleton->joints.size();
 			skeleton->frameData = new DirectX::XMFLOAT4X4[skeleton->jointCount];
 			// Check if any vertex has more than 4 weights assigned
 			for (unsigned int i = 0; i < temp.size(); ++i)
@@ -445,8 +440,6 @@ namespace {
 			CheckSumOfWeights(jointData);
 		}
 	}
-
-
 }
 
 
@@ -476,11 +469,6 @@ HRESULT FbxLoader::LoadFBX(const std::string& fileName, std::vector<DirectX::XMF
 	// Import model
 	bool b_success = p_importer->Initialize(fileName.c_str(), -1, gpFbxSdkManager->GetIOSettings());
 
-	//FbxAxisSystem direct_x_axis_system(FbxAxisSystem::eDirectX);
-	//if (p_fbx_scene.get()->GetGlobalSettings().GetAxisSystem() != direct_x_axis_system)
-	//{
-	//	direct_x_axis_system.ConvertScene(p_fbx_scene.get());
-	//}
 	// Handle failed import
 	if (!b_success)
 	{

--- a/DX11-Refresh/Fbx_Loader.cpp
+++ b/DX11-Refresh/Fbx_Loader.cpp
@@ -24,9 +24,9 @@ namespace {
 		// Convert FbxMatrix to XMFLOAT
 		for (int i = 0; i < 4; ++i)
 		{
-			for (int j = 0; j < 4; ++j)
+			for (int frame_index = 0; frame_index < 4; ++frame_index)
 			{
-				newMat.m[i][j] = static_cast<float>(toConvert->Get(i, j));
+				newMat.m[i][frame_index] = static_cast<float>(toConvert->Get(i, frame_index));
 			}
 		}
 		return newMat;
@@ -132,9 +132,9 @@ namespace {
 			uv_element->GetDirectArray().Clear();
 			uv_element->GetDirectArray().Resize(new_uvs.GetCount());
 			FbxVector2* direct_array = (FbxVector2*)uv_element->GetDirectArray().GetLocked();
-			for (int j = 0; j < new_uvs.GetCount(); ++j)
+			for (int frame_index = 0; frame_index < new_uvs.GetCount(); ++frame_index)
 			{
-				direct_array[j] = new_uvs.GetAt(j);
+				direct_array[frame_index] = new_uvs.GetAt(frame_index);
 			}
 			uv_element->GetDirectArray().Release((void**)& direct_array);
 		}
@@ -212,13 +212,17 @@ namespace {
 		if (curr_mesh)
 		{
 			unsigned int num_deformers = curr_mesh->GetDeformerCount();
+			if (num_deformers > 1)
+			{
+				throw std::exception("Mesh contains more than one deformer, the engine does not support this.");
+			}
 			// geometry transform is potentially something included with the model
 			// not all modeling programs provide this
 			// including it for safety because I don't know if blender does or not
 			FbxAMatrix geometry_transform = GetGeometryTransformation(inNode);
 			std::vector<std::vector<FbxLoader::IndexWeightPair>> temp(jointData->size(), std::vector<FbxLoader::IndexWeightPair>());
 
-			unsigned int animation_length = 0;
+			unsigned long long animation_length = 0;
 
 			// Loop through deformers
 			// Deformer is basically a skeleton
@@ -250,7 +254,7 @@ namespace {
 					// https://github.com/Larry955/FbxParser/blob/master/FbxParser/FbxParser.cpp - Row 781 & 993
 
 					// Fbx has every joint store the vertices it affects, we need to reverse this relationship
-					unsigned int num_of_indices = curr_cluster->GetControlPointIndicesCount();					
+					unsigned int num_of_indices = curr_cluster->GetControlPointIndicesCount();
 					for (unsigned int i = 0; i < num_of_indices; ++i)
 					{
 						FbxLoader::IndexWeightPair curr_index_weight_pair;
@@ -268,6 +272,7 @@ namespace {
 					{
 						std::string animation_name;
 						bool has_tpose = false;
+						// Find the TPOSE animation in the file and create the bindposeInverse transform for the joint
 						for (int anim_stack_index = 0; anim_stack_index < anim_stack_count; ++anim_stack_index)
 						{
 							curr_anim_stack = FbxCast<FbxAnimStack>(inNode->GetScene()->GetSrcObject<FbxAnimStack>(anim_stack_index));
@@ -304,22 +309,22 @@ namespace {
 						}
 						if (!has_tpose)
 						{
-							throw std::exception("Animated mesh does not have a 1 frame tpose action named \"TPOSE\", please create this animation.");
+							throw std::exception("Animated mesh does not have a 1 frame tpose animation/action named \"TPOSE\", please create this animation.");
 						}
 
 						curr_anim_stack = FbxCast<FbxAnimStack>(inNode->GetScene()->GetSrcObject<FbxAnimStack>(0));
-
-						// Get animation information
-						
 						FbxString anim_stack_name = curr_anim_stack->GetName();
 						animation_name = anim_stack_name.Buffer();
+						// Skip the TPOSE animation, we don't want it as a "usable" animation
+						if (animation_name.substr(animation_name.length() - 5) == std::string("TPOSE"))
+						{
+							continue;
+						}
+						// Get animation information
 						FbxTakeInfo* take_info = inNode->GetScene()->GetTakeInfo(anim_stack_name);
 						FbxTime start = curr_anim_stack->GetLocalTimeSpan().GetStart();
 						FbxTime end = curr_anim_stack->GetLocalTimeSpan().GetStop();
 						animation_length = (unsigned int)(end.GetFrameCount(FbxTime::eFrames24) - start.GetFrameCount(FbxTime::eFrames24) + 1);
-						
-
-
 						// Pre-reserve slots in the vector for the keyframes
 						curr_joint->mAnimationVector.reserve(animation_length);
 
@@ -357,10 +362,162 @@ namespace {
 							current_keyframe.mOffsetMatrix = FbxAMatrixToXMFLOAT4X4(&(offset_matrix.Transpose()));
 							curr_joint->mAnimationVector.push_back(current_keyframe);
 							loopCounter++;
-						}		
+						}
 					}
 
 
+				}
+
+				int anim_stack_count = inNode->GetScene()->GetSrcObjectCount<FbxAnimStack>();
+
+				// Before we calculate any offset matrices we need to find the TPOSE and calculate the bindpose inverse matrices
+				bool has_tpose = false;
+				// Find the TPOSE animation and calculate matrices
+				for (int anim_stack_index = 0; anim_stack_index < anim_stack_count && !has_tpose; ++anim_stack_index)
+				{
+					FbxAnimStack* curr_anim_stack = FbxCast<FbxAnimStack>(inNode->GetScene()->GetSrcObject<FbxAnimStack>(anim_stack_index));
+					FbxString anim_stack_name = curr_anim_stack->GetName();
+					std::string animation_name = anim_stack_name.Buffer();
+					std::string ending = animation_name.substr(animation_name.length() - 5);
+					// convert to uppercase in case animator forgot
+					std::transform(ending.begin(), ending.end(), ending.begin(), ::toupper);
+					if (ending == std::string("TPOSE"))
+					{
+						has_tpose = true;
+						for (int cluster_index = 0; cluster_index < num_of_clusters; ++cluster_index)
+						{
+							// Collect info about the current joint
+							FbxCluster* curr_cluster = curr_skin->GetCluster(cluster_index);
+							std::string curr_joint_name = curr_cluster->GetLink()->GetName();
+							unsigned int curr_joint_index = FindJointIndexUsingName(curr_joint_name, skeleton);
+							FbxLoader::Joint* curr_joint = &skeleton->joints[curr_joint_index];
+
+							// Evaluate the baseline global transform for the joint at t = 0 and create the global bindpose inverse matrix
+							FbxDouble3 rotInf = curr_cluster->GetLink()->LclRotation.EvaluateValue(FBXSDK_TIME_INFINITE);
+							FbxDouble3 translInf = curr_cluster->GetLink()->LclTranslation.EvaluateValue(FBXSDK_TIME_INFINITE);
+							FbxAMatrix bone_local_transform;
+							bone_local_transform = FbxAMatrix(translInf, rotInf, FbxVector4(1.0f, 1.0f, 1.0f));
+
+							if (curr_joint_index == 0)
+							{
+								curr_joint->mBoneGlobalTransform = bone_local_transform;
+							}
+							else
+							{
+								// FbxAMatrix performs matrix multiplication in REVERSE order, M1 * M2 is multiplied with M2 from the left
+								curr_joint->mBoneGlobalTransform = skeleton->joints[skeleton->joints[curr_joint_index].mParentIndex].mBoneGlobalTransform * bone_local_transform;
+
+							}
+							curr_joint->mGlobalBindposeInverse = curr_joint->mBoneGlobalTransform.Inverse() * FbxAMatrix(FbxVector4(0.0f, 0.0f, 0.0f), FbxVector4(-90.0f, 0.0f, 0.0f), FbxVector4(1.0f, -1.0f, 1.0f));
+						}
+					}
+
+				}
+				// If the mesh is animated but does not contain a TPOSE animation, throw an error
+				if (anim_stack_count > 0 && !has_tpose)
+				{
+					throw std::exception("Animated mesh does not have a 1 frame tpose animation/action named \"TPOSE\", please create this animation.");
+				}
+				std::vector<FbxLoader::AnimationSet> tempAnimationSetsVector;
+				tempAnimationSetsVector.reserve(anim_stack_count - 1);
+				for (int anim_stack_index = 0; anim_stack_index < anim_stack_count; ++anim_stack_index)
+				{
+					FbxAnimStack* curr_anim_stack = FbxCast<FbxAnimStack>(inNode->GetScene()->GetSrcObject<FbxAnimStack>(anim_stack_index));
+					FbxString anim_stack_name = curr_anim_stack->GetName();
+					std::string animation_name = anim_stack_name.Buffer();
+					std::string ending = animation_name.substr(animation_name.length() - 5);
+					// convert to uppercase in case animator forgot
+					std::transform(ending.begin(), ending.end(), ending.begin(), ::toupper);
+					// Skip the TPOSE "animation", we don't want it as a useable animation
+					if (ending == std::string("TPOSE"))
+					{
+						continue;
+					}
+
+					// Get animation information
+					FbxTime start = curr_anim_stack->GetLocalTimeSpan().GetStart();
+					FbxTime end = curr_anim_stack->GetLocalTimeSpan().GetStop();
+					animation_length = (unsigned long long)(end.GetFrameCount(FbxTime::eFrames24) - start.GetFrameCount(FbxTime::eFrames24) + 1);
+
+					// Create the AnimationSet for this animation
+					FbxLoader::AnimationSet tempAnimSet;
+					tempAnimSet.frameCount = animation_length;
+					tempAnimSet.animationName = animation_name;
+
+					std::vector<DirectX::XMFLOAT4X4> tempJointOffsetMatrixVector;
+
+					FbxAnimEvaluator* anim_eval = inNode->GetScene()->GetAnimationEvaluator();
+					FbxNodeEvalState* evalstate;
+					
+					
+
+					// bindposes have already been calculated at this point, we just need the offset matrices for each joint
+					for (int cluster_index = 0; cluster_index < num_of_clusters; ++cluster_index)
+					{
+						// Collect info about the current joint
+						FbxCluster* curr_cluster = curr_skin->GetCluster(cluster_index);
+						std::string curr_joint_name = curr_cluster->GetLink()->GetName();
+						unsigned int curr_joint_index = FindJointIndexUsingName(curr_joint_name, skeleton);
+						FbxLoader::Joint* curr_joint = &skeleton->joints[curr_joint_index];
+						skeleton->joints[curr_joint_index].mNode = curr_cluster->GetLink();
+
+						// Pre-reserve slots in the vector for the keyframes
+						curr_joint->mAnimationVector.reserve(animation_length); // LEGACY CODE
+
+						unsigned int loopCounter = 0;
+						for (FbxLongLong i = start.GetFrameCount(FbxTime::eFrames24); i <= end.GetFrameCount(FbxTime::eFrames24); ++i)
+						{
+							FbxLoader::KeyFrame current_keyframe;
+
+							FbxTime curr_time;
+							curr_time.SetFrame(i, FbxTime::eFrames24);
+
+							current_keyframe.mFrameNum = i;
+
+							// Evaluate the local transform of the joint at the current time
+							inNode->GetScene()->SetCurrentAnimationStack(curr_anim_stack);
+							FbxDouble3 rot = curr_cluster->GetLink()->LclRotation.EvaluateValue(curr_time, true);
+							FbxDouble3 transl = curr_cluster->GetLink()->LclTranslation.EvaluateValue(curr_time, true);
+							current_keyframe.mLocalTransform = FbxAMatrix(transl, rot, FbxVector4(1.0f, 1.0f, 1.0f));
+							// If joint is root, use local transform as global
+							// else, multiply with parent global first
+							if (curr_joint_index == 0)
+							{
+								current_keyframe.mGlobalTransform = current_keyframe.mLocalTransform;
+							}
+							else
+							{
+								// FbxAMatrix performs matrix multiplication in REVERSE order, M1 * M2 is multiplied with M2 from the left
+								current_keyframe.mGlobalTransform = skeleton->joints[skeleton->joints[curr_joint_index].mParentIndex].mAnimationVector[loopCounter].mGlobalTransform * current_keyframe.mLocalTransform;
+							}
+							FbxAMatrix offset_matrix;
+							// FbxAMatrix performs matrix multiplication in REVERSE order, M1 * M2 is multiplied with M2 from the left
+							offset_matrix = FbxAMatrix(FbxVector4(0.0f, 0.0f, 0.0f), FbxVector4(-90.0f, 0.0f, 0.0f), FbxVector4(1.0f, -1.0f, 1.0f)) * (current_keyframe.mGlobalTransform * curr_joint->mGlobalBindposeInverse);
+							// Matrix needs to be transposed before sending to the GPU
+							current_keyframe.mOffsetMatrix = FbxAMatrixToXMFLOAT4X4(&(offset_matrix.Transpose())); // LEGACY
+							curr_joint->mAnimationVector.push_back(current_keyframe); // LEGACY
+
+							tempJointOffsetMatrixVector.push_back(FbxAMatrixToXMFLOAT4X4(&(offset_matrix.Transpose())));
+							skeleton->joints[curr_joint_index].mAnimationVector[loopCounter].mGlobalTransform = current_keyframe.mGlobalTransform;
+							loopCounter++;
+						}
+					}
+
+					// Fill the Animation Set with the collected data
+					tempAnimSet.animationData = new DirectX::XMFLOAT4X4[animation_length * num_of_clusters];
+					for (int frame_index = 0; frame_index < animation_length; ++frame_index)
+					{
+						for (int joint_index = 0; joint_index < num_of_clusters; ++joint_index)
+						{
+							tempAnimSet.animationData[frame_index * num_of_clusters + joint_index] = tempJointOffsetMatrixVector[joint_index * animation_length + frame_index];
+						}
+					}
+					tempAnimationSetsVector.push_back(tempAnimSet);
+				}
+				for (int i = 0; i < tempAnimationSetsVector.size(); ++i)
+				{
+					skeleton->animations[i] = tempAnimationSetsVector[i];
+					skeleton->animationFlags[i] = 0;
 				}
 			}
 			skeleton->jointCount = skeleton->joints.size();
@@ -368,19 +525,20 @@ namespace {
 			skeleton->animationData = new DirectX::XMFLOAT4X4[skeleton->jointCount * animation_length];
 			for (int i = 0; i < skeleton->jointCount; ++i)
 			{
-				for (int j = 0; j < animation_length; ++j)
+				for (int frame_index = 0; frame_index < animation_length; ++frame_index)
 				{
-					skeleton->animationData[j * skeleton->jointCount + i] = (skeleton->joints[i].mAnimationVector[j].mOffsetMatrix);
+					skeleton->animationData[frame_index * skeleton->jointCount + i] = (skeleton->joints[i].mAnimationVector[frame_index].mOffsetMatrix);
 				}
 			}
+
 
 			// Check if any vertex has more than 4 weights assigned
 			for (unsigned int i = 0; i < temp.size(); ++i)
 			{
-				for (unsigned int j = 0; j < temp[i].size(); ++j)
+				for (unsigned int frame_index = 0; frame_index < temp[i].size(); ++frame_index)
 				{
-					(*jointData)[i].weightPairs[j] = temp[i][j];
-					if (j >= MAX_NUM_WEIGHTS_PER_VERTEX)
+					(*jointData)[i].weightPairs[frame_index] = temp[i][frame_index];
+					if (frame_index >= MAX_NUM_WEIGHTS_PER_VERTEX)
 					{
 						throw std::exception("Mesh contains vertices with more than 4 bone weights. The engine does not support this.");
 					}
@@ -490,12 +648,12 @@ HRESULT FbxLoader::LoadFBX(const std::string& fileName, std::vector<DirectX::XMF
 				// Transform the mesh using the appropriate root transformation matrix
 
 				
-				for (int j = 0; j < p_mesh->GetControlPointsCount(); ++j)
+				for (int frame_index = 0; frame_index < p_mesh->GetControlPointsCount(); ++frame_index)
 				{
 					FbxAMatrix conversion_transform = FbxAMatrix(FbxVector4(0.0f, 0.0f, 0.0f), FbxVector4(-90.0f, 0.0f, 0.0f), FbxVector4(1.0f, -1.0f, 1.0f));
 					DirectX::XMFLOAT3 vertex_pos;
-					FbxVector4 fbx_vertex = p_vertices[j];
-					fbx_vertex = conversion_transform.MultT(p_vertices[j]);
+					FbxVector4 fbx_vertex = p_vertices[frame_index];
+					fbx_vertex = conversion_transform.MultT(p_vertices[frame_index]);
 					vertex_pos.x = (float)fbx_vertex.mData[0];
 					vertex_pos.y = (float)fbx_vertex.mData[1];
 					vertex_pos.z = (float)fbx_vertex.mData[2];
@@ -503,7 +661,7 @@ HRESULT FbxLoader::LoadFBX(const std::string& fileName, std::vector<DirectX::XMF
 
 
 					// Save to control point info map 
-					//control_points_info[j].ctrlPoint = p_mesh->GetControlPointAt(j);
+					//control_points_info[frame_index].ctrlPoint = p_mesh->GetControlPointAt(frame_index);
 
 					fbxsdk::FbxVector4 normal;
 					// If the mesh normals are not in "per vertex" mode, re-generate them to be useable by this parser
@@ -517,11 +675,11 @@ HRESULT FbxLoader::LoadFBX(const std::string& fileName, std::vector<DirectX::XMF
 					switch (le_normal->GetReferenceMode())
 					{
 					case FbxGeometryElement::eDirect:
-						normal = le_normal->GetDirectArray().GetAt(j).mData;
+						normal = le_normal->GetDirectArray().GetAt(frame_index).mData;
 						break;
 					case FbxGeometryElement::eIndexToDirect:
 					{
-						int index = le_normal->GetIndexArray().GetAt(j);
+						int index = le_normal->GetIndexArray().GetAt(frame_index);
 						normal = le_normal->GetDirectArray().GetAt(index).mData;
 						break;
 					}

--- a/DX11-Refresh/Fbx_loader.h
+++ b/DX11-Refresh/Fbx_loader.h
@@ -85,13 +85,15 @@ struct AnimationSet
 
 struct Skeleton {
 	std::vector<Joint> joints;
-	DirectX::XMFLOAT4X4* animationData;
-	unsigned int jointCount;
-	unsigned int frameCount;
+	DirectX::XMFLOAT4X4* animationData; // Legacy, to be removed
+	unsigned int jointCount = 0;
+	unsigned int frameCount = 0; // Legacy, to be removed
 
 	AnimationSet animations[ANIMATION_COUNT];
-	int animationFlags[ANIMATION_COUNT];
-	Skeleton()
+	int animationFlags[ANIMATION_COUNT]; // -1 : missing animation
+										 // 0  : disabled
+										 // 1  : enabled
+	Skeleton() 
 	{
 		// Initialize the animation flags with -1 for missing animation
 		std::fill(animationFlags, animationFlags + ANIMATION_COUNT, -1);

--- a/DX11-Refresh/Fbx_loader.h
+++ b/DX11-Refresh/Fbx_loader.h
@@ -12,151 +12,343 @@
 #include <locale>
 
 #define MAX_NUM_WEIGHTS_PER_VERTEX 4
-
+#define ANIMATION_CROSSFADE_DURATION 1.0f
 
 namespace FbxLoader
 {
 
-struct FbxVertex
-{
-	float pos[3];
-	float nor[3];
-	float uv[2];
-};
-
-//This stores the weight of each Control Point
-struct IndexWeightPair
-{
-	unsigned int index;	//index of joint 
-	double weight;		//weight of influence by the joint
-	IndexWeightPair() :
-		index(0), weight(0.0)
-	{}
-};
-
-
-// Each vertex contains up to four IndexWeightPairs
-struct ControlPointInfo
-{
-	IndexWeightPair weightPairs[4];
-};
-
-//This stores the information of each key frame of each Joint
-struct KeyFrame {
-	FbxLongLong mFrameNum;
-	FbxAMatrix mGlobalTransform;	//global transform not including bindpose inverse transform matrix
-	FbxAMatrix mLocalTransform;
-	DirectX::XMFLOAT4X4 mOffsetMatrix; // final offset matrix, this is what needs to be sent to the GPU
-};
-
-struct Joint {
-	std::string mName;
-	int mParentIndex;	//index to its parent joint
-
-	std::vector<KeyFrame> mAnimationVector;
-	FbxNode* mNode;
-
-	std::vector<unsigned int> mConnectedVertexIndices;
-
-	FbxAMatrix mGlobalBindposeInverse;
-	FbxAMatrix mBoneGlobalTransform;
-	FbxAMatrix mOffsetMatrix;
-
-	Joint() :
-		mNode(nullptr)
+	struct FbxVertex
 	{
-		mParentIndex = -1;
-	}
-};
+		float pos[3];
+		float nor[3];
+		float uv[2];
+	};
 
-enum ANIMATION_TYPE
-{
-	IDLE,
-	MOVE,
-	ATTACK,
-	ANIMATION_COUNT
-};
-
-struct AnimationSet
-{
-	DirectX::XMFLOAT4X4* animationData;
-	unsigned int frameCount;
-	unsigned int activeFrame = 0;
-	std::string animationName;
-};
-
-struct Skeleton {
-private:  
-	float mCurrentTime = 0;
-
-public:
-	std::vector<Joint> joints;
-	DirectX::XMFLOAT4X4* animationData; // LEGACY, please use UpdateAnimation and frameData instead
-	DirectX::XMFLOAT4X4* frameData;
-	unsigned int jointCount = 0;
-	unsigned int frameCount = 0;
-	AnimationSet animations[ANIMATION_COUNT];
-	int animationFlags[ANIMATION_COUNT]; // -1 : missing animation
-										 // 0  : disabled
-										 // 1  : enabled
-	Skeleton() 
+	//This stores the weight of each Control Point
+	struct IndexWeightPair
 	{
-		// Initialize the animation flags with -1 for missing animation
-		std::fill(animationFlags, animationFlags + ANIMATION_COUNT, -1);
-	}
-	// Currently does not blend animations, simply updates the global animationData with info from the first enabled animation.
-	void UpdateAnimation(float dtInSeconds)
-	{
+		unsigned int index;	//index of joint 
+		double weight;		//weight of influence by the joint
+		IndexWeightPair() :
+			index(0), weight(0.0)
+		{}
+	};
 
-		for (int i = 0; i < ANIMATION_COUNT; ++i)
+
+	// Each vertex contains up to four IndexWeightPairs
+	struct ControlPointInfo
+	{
+		IndexWeightPair weightPairs[4];
+	};
+
+	//This stores the information of each key frame of each Joint
+	struct KeyFrame {
+		FbxLongLong mFrameNum;
+		FbxAMatrix mGlobalTransform;	//global transform not including bindpose inverse transform matrix
+		FbxAMatrix mLocalTransform;
+		DirectX::XMFLOAT4X4 mOffsetMatrix; // final offset matrix, this is what needs to be sent to the GPU
+	};
+
+	struct Joint {
+		std::string mName;
+		int mParentIndex;	//index to its parent joint
+		std::vector<KeyFrame> mAnimationVector;
+		FbxNode* mNode;
+
+		std::vector<unsigned int> mConnectedVertexIndices;
+
+		FbxAMatrix mGlobalBindposeInverse;
+		FbxAMatrix mBoneGlobalTransform;
+		FbxAMatrix mOffsetMatrix;
+
+		Joint() :
+			mNode(nullptr)
 		{
-			if (this->animationFlags[i] == 1)
+			mParentIndex = -1;
+		}
+	};
+
+	enum ANIMATION_TYPE
+	{
+		PING,
+		IDLE,
+		MOVE,
+		ATTACK,
+		ANIMATION_COUNT
+	};
+
+	struct AnimationSet
+	{
+		DirectX::XMFLOAT4X4* animationData;
+		unsigned int frameCount;
+		unsigned int activeFrame = 0;
+		std::string animationName;
+	};
+
+
+
+	struct Skeleton {
+	private:
+		float mCurrentTime = 0;
+
+	public:
+		std::vector<Joint> joints;
+		DirectX::XMFLOAT4X4* animationData; // LEGACY, please use UpdateAnimation and frameData instead
+		DirectX::XMFLOAT4X4* frameData;
+		unsigned int jointCount = 0;
+		unsigned int frameCount = 0;
+		AnimationSet animations[ANIMATION_COUNT];
+		int animationFlags[ANIMATION_COUNT]; // -1 : missing animation
+											 // 0  : disabled
+											 // 1  : enabled
+		Skeleton()
+		{
+			// Initialize the animation flags with -1 for missing animation
+			std::fill(animationFlags, animationFlags + ANIMATION_COUNT, -1);
+		}
+		// Currently does not blend animations, simply updates the global animationData with info from the first enabled animation.
+		void UpdateAnimation(float dtInSeconds)
+		{
+
+			for (int i = 0; i < ANIMATION_COUNT; ++i)
 			{
-				this->animationData = animations[i].animationData;
-				this->frameCount = animations[i].frameCount;
+				if (this->animationFlags[i] == 1)
+				{
+					this->animationData = animations[i].animationData;
+					this->frameCount = animations[i].frameCount;
+					this->mCurrentTime = this->mCurrentTime + dtInSeconds;
+					int frame_to_set = (int)std::round(fmod(this->mCurrentTime * 60.0f, this->frameCount)) % this->frameCount;
+					// Get frame data from animationData vector
+					memcpy(this->frameData, &animations[i].animationData[frame_to_set * this->jointCount], this->jointCount * sizeof(DirectX::XMFLOAT4X4));
+					break; // This break will disappear when animation blending is implemented
+				}
+			}
+		}
+		// Returns false if requested animation does not exist
+		bool StartAnimation(ANIMATION_TYPE anim_type)
+		{
+			if (anim_type < ANIMATION_COUNT)
+			{
+				if (this->animationFlags[anim_type] != -1)
+				{
+					this->animationFlags[anim_type] = 1;
+					this->animations[anim_type].activeFrame = 0;
+					return true;
+				}
+			}
+			return false;
+		}
+		// Returns false if requested animation does not exist
+		bool StopAnimation(ANIMATION_TYPE anim_type)
+		{
+			if (anim_type < ANIMATION_COUNT)
+			{
+				if (this->animationFlags[anim_type] != -1)
+				{
+					this->animationFlags[anim_type] = 0;
+					return true;
+				}
+			}
+			return false;
+		}
+	};
+
+	struct UniqueSkeletonData
+	{
+	private:
+		float mCurrentTime = 0.0f;
+		float mPrevTime = 0.0f;
+		// Default to idle
+		int mActiveAnimation = (int)FbxLoader::ANIMATION_TYPE::IDLE;
+		int mPrevAnimation = -1;
+
+		float mPrevAnimTransitionTime = -1.0f;
+	public:
+
+		Skeleton* parentSkeleton;
+		DirectX::XMFLOAT4X4* frameData;
+		int animationFlags[ANIMATION_COUNT];
+		UniqueSkeletonData()
+		{
+
+		}
+		void ResetFrameCount()
+		{
+			this->mCurrentTime = 0.0f + static_cast <float> (rand()) / static_cast <float> (RAND_MAX);
+		}
+		void Init(Skeleton* parentSkeleton)
+		{
+			this->parentSkeleton = parentSkeleton;
+			this->frameData = new DirectX::XMFLOAT4X4[parentSkeleton->jointCount];
+			for (int i = 0; i < ANIMATION_COUNT; ++i)
+			{
+				this->animationFlags[i] = parentSkeleton->animationFlags[i];
+			}
+		}
+		void UpdateAnimation(float dtInSeconds, ANIMATION_TYPE animType)
+		{
+			// If we are swapping animation
+			if (mActiveAnimation != (int)animType)
+			{
+				// This prevents super quick switching of animations, and only updates prevanimation if the
+				// current animation has been playing for AT LEAST a few frames
+				if (mPrevAnimTransitionTime < ANIMATION_CROSSFADE_DURATION - 0.05f)
+				{
+					mPrevTime = mCurrentTime;
+					ResetFrameCount();
+					mPrevAnimation = mActiveAnimation;
+				}
+
+				mActiveAnimation = (int)animType;
+				mPrevAnimTransitionTime = ANIMATION_CROSSFADE_DURATION;
+			}
+
+			if (this->animationFlags[animType] != -1)
+			{
+				int frame_count = this->parentSkeleton->animations[animType].frameCount;
+				int joint_count = this->parentSkeleton->jointCount;
 				this->mCurrentTime = this->mCurrentTime + dtInSeconds;
-				int frame_to_set = (int)std::round(fmod(this->mCurrentTime * 24.0f, this->frameCount)) % this->frameCount;
+				int frame_to_set = (int)std::round(fmod(this->mCurrentTime * 60.0f, frame_count)) % frame_count;
 				// Get frame data from animationData vector
-				memcpy(this->frameData, &animations[i].animationData[frame_to_set * this->jointCount], this->jointCount * sizeof(DirectX::XMFLOAT4X4));
-				break; // This break will disappear when animation blending is implemented
-			}
-		}
-	}
-	// Returns false if requested animation does not exist
-	bool StartAnimation(ANIMATION_TYPE anim_type)
-	{
-		if (anim_type < ANIMATION_COUNT)
-		{
-			if (this->animationFlags[anim_type] != -1)
-			{
-				this->animationFlags[anim_type] = 1;
-				this->animations[anim_type].activeFrame = 0;
-				return true;
-			}
-		}
-		return false;
-	}
-	// Returns false if requested animation does not exist
-	bool StopAnimation(ANIMATION_TYPE anim_type)
-	{
-		if (anim_type < ANIMATION_COUNT)
-		{
-			if (this->animationFlags[anim_type] != -1)
-			{
-				this->animationFlags[anim_type] = 0;
-				return true;
-			}
-		}
-		return false;
-	}
-};
+				memcpy(this->frameData, &this->parentSkeleton->animations[animType].animationData[frame_to_set * joint_count], joint_count * sizeof(DirectX::XMFLOAT4X4));
 
+				// If we are currently transitioning between two animations
+				if (mPrevAnimTransitionTime >= 0.0f)
+				{
+					mPrevTime += dtInSeconds;
+					float prev_weight = mPrevAnimTransitionTime / ANIMATION_CROSSFADE_DURATION;
+					//float current_weight = 1.0f - prev_weight;
+					int prev_frame_count = this->parentSkeleton->animations[mPrevAnimation].frameCount;
+					DirectX::XMFLOAT4X4* prevFrameData = new DirectX::XMFLOAT4X4[parentSkeleton->jointCount];
+					int prev_frame_to_set = (int)std::round(fmod(this->mPrevTime * 60.0f, prev_frame_count)) % prev_frame_count;
+					// Get frame data from animationData vector for the PREVIOUS animation
+					// Same procedure as current animation
+					memcpy(prevFrameData,
+						&this->parentSkeleton->animations[mPrevAnimation].animationData[prev_frame_to_set * joint_count],
+						joint_count * sizeof(DirectX::XMFLOAT4X4));
+					// For each joint, decompose the two animation matrices and interpolate them, combine to a "final" animation matrix
+					for (unsigned int i = 0; i < this->parentSkeleton->jointCount; ++i)
+					{
+						DirectX::XMVECTOR current_frame_scale, current_frame_rot, current_frame_trans;
+						DirectX::XMVECTOR prev_frame_scale, prev_frame_rot, prev_frame_trans;
+						DirectX::XMVECTOR new_frame_scale, new_frame_rot, new_frame_trans;
+						// Transposing both matrices as they are currently in shader-readable format
+						DirectX::XMMATRIX current_frame_matrix = DirectX::XMMatrixTranspose(DirectX::XMLoadFloat4x4(&this->frameData[i]));
+						DirectX::XMMATRIX prev_frame_matrix = DirectX::XMMatrixTranspose(DirectX::XMLoadFloat4x4(&prevFrameData[i]));
+						// Decompose the matrix in order to be able to interpolate the components
+						DirectX::XMMatrixDecompose(&current_frame_scale, &current_frame_rot, &current_frame_trans, current_frame_matrix);
+						DirectX::XMMatrixDecompose(&prev_frame_scale, &prev_frame_rot, &prev_frame_trans, prev_frame_matrix);
+
+						// Calculate the interpolated components of the new matrix
+						new_frame_rot = DirectX::XMQuaternionSlerp(current_frame_rot, prev_frame_rot, prev_weight);
+						new_frame_scale = DirectX::XMVectorLerp(current_frame_scale, prev_frame_scale, prev_weight);
+						new_frame_trans = DirectX::XMVectorLerp(current_frame_trans, prev_frame_trans, prev_weight);
+
+						// Transposing the new matrix to convert it back to shader readable format
+						DirectX::XMMATRIX new_frame_matrix = DirectX::XMMatrixTranspose(
+							DirectX::XMMatrixScalingFromVector(new_frame_scale) *
+							DirectX::XMMatrixRotationQuaternion(new_frame_rot) *
+							DirectX::XMMatrixTranslationFromVector(new_frame_trans));
+						// Store the new matrix in framedata
+						XMStoreFloat4x4(&this->frameData[i], new_frame_matrix);
+					}
+					// Reduce the transition timer
+					mPrevAnimTransitionTime -= dtInSeconds;
+					delete[] prevFrameData;
+				}
+			}
+		}
+		// Returns false if requested animation does not exist
+		bool StartAnimation(ANIMATION_TYPE anim_type)
+		{
+			if (anim_type < ANIMATION_COUNT)
+			{
+				if (this->animationFlags[anim_type] != -1)
+				{
+					this->animationFlags[anim_type] = 1;
+					this->mCurrentTime = 0.0f;
+					return true;
+				}
+			}
+			return false;
+		}
+		// Returns false if requested animation does not exist
+		bool StopAnimation(ANIMATION_TYPE anim_type)
+		{
+			if (anim_type < ANIMATION_COUNT)
+			{
+				if (this->animationFlags[anim_type] != -1)
+				{
+					this->animationFlags[anim_type] = 0;
+					return true;
+				}
+			}
+			return false;
+		}
+		DirectX::XMFLOAT4X4 GetOffsetMatrixUsingJointName(const std::string& inJointName)
+		{
+			int joint_index = -1;
+			for (unsigned int i = 0; i < this->parentSkeleton->joints.size(); ++i)
+			{
+				if (this->parentSkeleton->joints[i].mName == inJointName)
+				{
+					joint_index = i;
+					break;
+				}
+			}
+
+			if (joint_index >= 0) // if joint name existed
+			{
+				// Animation data layout reminder:
+				// [[[ |FRAME 0| joint0mat joint1mat joint2mat ... jointnmat |FRAME 1| joint0mat joint1mat joint2mat ... jointnmat |FRAME 2| ....... ]]]
+				return this->frameData[joint_index];
+			}
+			else
+			{
+				// Return error matrix
+				return DirectX::XMFLOAT4X4(-1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f);
+			}
+		}
+
+		DirectX::XMFLOAT4X4 GetInverseBindPoseUsingJointName(const std::string& inJointName)
+		{
+			int joint_index = -1;
+			for (unsigned int i = 0; i < this->parentSkeleton->joints.size(); ++i)
+			{
+				if (this->parentSkeleton->joints[i].mName == inJointName)
+				{
+					joint_index = i;
+					break;
+				}
+			}
+
+			if (joint_index >= 0) // if joint name existed
+			{
+				DirectX::XMFLOAT4X4 new_mat;
+				// Convert FbxMatrix to XMFLOAT
+				for (int i = 0; i < 4; ++i)
+				{
+					for (int j = 0; j < 4; ++j)
+					{
+						new_mat.m[i][j] = static_cast<float>(parentSkeleton->joints[joint_index].mGlobalBindposeInverse.Get(i, j));
+					}
+				}
+				return new_mat;
+			}
+			else
+			{
+				// Return error matrix
+				return DirectX::XMFLOAT4X4(-1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f);
+			}
+		}
+	};
 
 	// Used for loading the very basics of an FBX
 	// Input: std::string file name of FBX file, pointers to std::vectors to append the data to
-	// Output: Appends XMFLOAT3 vertex positions and int indices to provided vectors
+	// Output: Appends data to the provided vectors, returns HRESULT
 	HRESULT LoadFBX(const std::string& fileName, std::vector<DirectX::XMFLOAT3>* pOutVertexPosVector, std::vector<int>* pOutIndexVector,
-		std::vector<DirectX::XMFLOAT3>* pOutNormalVector, std::vector<DirectX::XMFLOAT2>* pOutUVVector, Skeleton* pOutSkeleton, std::vector<ControlPointInfo>* pOutCPInfoVector);
+		std::vector<DirectX::XMFLOAT3>* pOutNormalVector, std::vector<DirectX::XMFLOAT2>* pOutUVVector, Skeleton* pOutSkeleton, std::vector<FbxLoader::ControlPointInfo>* pOutCPInfoVector);
+
 
 
 }

--- a/DX11-Refresh/Fbx_loader.h
+++ b/DX11-Refresh/Fbx_loader.h
@@ -9,6 +9,7 @@
 #include <DirectXMath.h>
 #include <memory>
 #include <algorithm>
+#include <locale>
 
 #define MAX_NUM_WEIGHTS_PER_VERTEX 4
 
@@ -80,7 +81,8 @@ struct AnimationSet
 {
 	DirectX::XMFLOAT4X4* animationData;
 	unsigned int frameCount;
-
+	unsigned int activeFrame = 0;
+	std::string animationName;
 };
 
 struct Skeleton {
@@ -97,6 +99,45 @@ struct Skeleton {
 	{
 		// Initialize the animation flags with -1 for missing animation
 		std::fill(animationFlags, animationFlags + ANIMATION_COUNT, -1);
+	}
+	// Currently does not utilize dt nor blends animations, simply updates the global animationData with info from the first enabled animation.
+	void UpdateAnimation(float dt)
+	{
+		for (int i = 0; i < ANIMATION_COUNT; ++i)
+		{
+			if (this->animationFlags[i] == 1)
+			{
+				this->animationData = animations[i].animationData;
+				this->frameCount = animations[i].frameCount;
+			}
+		}
+	}
+	// Returns false if requested animation does not exist
+	bool StartAnimation(ANIMATION_TYPE anim_type)
+	{
+		if (anim_type < ANIMATION_COUNT)
+		{
+			if (this->animationFlags[anim_type] != -1)
+			{
+				this->animationFlags[anim_type] = 1;
+				this->animations[anim_type].activeFrame = 0;
+				return true;
+			}
+		}
+		return false;
+	}
+	// Returns false if requested animation does not exist
+	bool StopAnimation(ANIMATION_TYPE anim_type)
+	{
+		if (anim_type < ANIMATION_COUNT)
+		{
+			if (this->animationFlags[anim_type] != -1)
+			{
+				this->animationFlags[anim_type] = 0;
+				return true;
+			}
+		}
+		return false;
 	}
 };
 

--- a/DX11-Refresh/Fbx_loader.h
+++ b/DX11-Refresh/Fbx_loader.h
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <DirectXMath.h>
 #include <memory>
+#include <algorithm>
 
 #define MAX_NUM_WEIGHTS_PER_VERTEX 4
 
@@ -67,11 +68,34 @@ struct Joint {
 	}
 };
 
+enum ANIMATION_TYPE
+{
+	IDLE,
+	MOVE,
+	ATTACK,
+	ANIMATION_COUNT
+};
+
+struct AnimationSet
+{
+	DirectX::XMFLOAT4X4* animationData;
+	unsigned int frameCount;
+
+};
+
 struct Skeleton {
 	std::vector<Joint> joints;
 	DirectX::XMFLOAT4X4* animationData;
 	unsigned int jointCount;
 	unsigned int frameCount;
+
+	AnimationSet animations[ANIMATION_COUNT];
+	int animationFlags[ANIMATION_COUNT];
+	Skeleton()
+	{
+		// Initialize the animation flags with -1 for missing animation
+		std::fill(animationFlags, animationFlags + ANIMATION_COUNT, -1);
+	}
 };
 
 

--- a/DX11-Refresh/Renderer.cpp
+++ b/DX11-Refresh/Renderer.cpp
@@ -178,16 +178,17 @@ void Renderer::Frame()
 	}
 	if (animate)
 	{
-		if (rotation > 0.01f || rotation < -0.01f)
+		if (true)
 		{
-			this->skinSkeletons[0]->UpdateAnimation(0.0f);
+			this->skinSkeletons[0]->UpdateAnimation(this->gameTimer.DeltaTime());
 			currentAnimFrame = (currentAnimFrame + 1) % this->skinSkeletons[0]->frameCount;
 			VS_BONE_CONSTANT_BUFFER vsConstData = {};
 
 			// ------------ NEW SYSTEM -----------------
 
 			DirectX::XMFLOAT4X4* anim_data = this->skinSkeletons[0]->animationData;
-			memcpy(&vsConstData.mBoneTransforms[0], &anim_data[currentAnimFrame * this->skinSkeletons[0]->jointCount], this->skinSkeletons[0]->jointCount * sizeof(XMFLOAT4X4));
+			//memcpy(&vsConstData.mBoneTransforms[0], &anim_data[currentAnimFrame * this->skinSkeletons[0]->jointCount], this->skinSkeletons[0]->jointCount * sizeof(XMFLOAT4X4));
+			memcpy(&vsConstData.mBoneTransforms[0], this->skinSkeletons[0]->frameData, this->skinSkeletons[0]->jointCount * sizeof(XMFLOAT4X4));
 
 			this->mDeviceContext->UpdateSubresource(
 				this->mBoneTransformBuffer,

--- a/DX11-Refresh/Renderer.cpp
+++ b/DX11-Refresh/Renderer.cpp
@@ -163,18 +163,29 @@ void Renderer::Frame()
 
 	if (rotation > 0.01f || rotation < -0.01f)
 	{
-
-
 		animate = true;
+		
+		if (rotation > 0.01f)
+		{
+			this->skinSkeletons[0]->StartAnimation(FbxLoader::ANIMATION_TYPE::IDLE);
+			this->skinSkeletons[0]->StopAnimation(FbxLoader::ANIMATION_TYPE::MOVE);
+		}
+		else if (rotation < 0.01f)
+		{
+			this->skinSkeletons[0]->StartAnimation(FbxLoader::ANIMATION_TYPE::MOVE);
+			this->skinSkeletons[0]->StopAnimation(FbxLoader::ANIMATION_TYPE::IDLE);
+		}
 	}
 	if (animate)
 	{
-		if (timeThisFrame - timeLastFrame > 0.04166666666f)
+		if (rotation > 0.01f || rotation < -0.01f)
 		{
+			this->skinSkeletons[0]->UpdateAnimation(0.0f);
 			currentAnimFrame = (currentAnimFrame + 1) % this->skinSkeletons[0]->frameCount;
 			VS_BONE_CONSTANT_BUFFER vsConstData = {};
 
 			// ------------ NEW SYSTEM -----------------
+
 			DirectX::XMFLOAT4X4* anim_data = this->skinSkeletons[0]->animationData;
 			memcpy(&vsConstData.mBoneTransforms[0], &anim_data[currentAnimFrame * this->skinSkeletons[0]->jointCount], this->skinSkeletons[0]->jointCount * sizeof(XMFLOAT4X4));
 

--- a/DX11-Refresh/SkinningVS.hlsl
+++ b/DX11-Refresh/SkinningVS.hlsl
@@ -50,6 +50,6 @@ VSOut SKIN_VS(SKIN_VSIn input)
 	output.UV = input.UV;
 	output.Color = float4(input.Normal, 1.0f);
 	// Used for normal testing purposes to assign colour in the pixel shader
-	output.worldPos = float3(v.xyz);
+	output.worldPos = norm;
 	return output;
 }


### PR DESCRIPTION
The loader now supports loading multiple baked animations in the same .fbx file.

Currently supported animations in the ANIMATION_TYPE enum include

- PING, IDLE, MOVE, ATTACK

These names are merely semantics and are loaded in order of appearance in the file alphabetically.